### PR TITLE
Add the current thread name in the message

### DIFF
--- a/src/main/java/com/beachape/auth/MyAuthIdentityProvider.java
+++ b/src/main/java/com/beachape/auth/MyAuthIdentityProvider.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 
 import org.jboss.logging.Logger;
 
+import static com.beachape.logging.MessageUtils.formatMessageWithThread;
+
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -23,14 +25,16 @@ public class MyAuthIdentityProvider implements IdentityProvider<MyAuthRequest> {
 
     @Override
     public Uni<SecurityIdentity> authenticate(MyAuthRequest request, AuthenticationRequestContext context) {
-        LOGGER.info("Handling authentication in MyAuthIdentityProvider for user: " + request.getUsername());
-        LOGGER.info("Simulating IO by sleeping for 5 seconds");
+        LOGGER.info(formatMessageWithThread(
+                "Handling authentication in MyAuthIdentityProvider for user: " + request.getUsername()));
+        LOGGER.info(formatMessageWithThread("Simulating IO by sleeping for 5 seconds"));
         try {
             Thread.sleep(Duration.ofSeconds(5).toMillis()); // Simulate IO operation
         } catch (InterruptedException e) {
             LOGGER.error("Thread interrupted during sleep", e);
         }
-        LOGGER.info("Done sleeping, creating SecurityIdentity for user: " + request.getUsername());
+        LOGGER.info(
+                formatMessageWithThread("Done sleeping, creating SecurityIdentity for user: " + request.getUsername()));
         SecurityIdentity identity = QuarkusSecurityIdentity.builder()
                 .setPrincipal(() -> request.getUsername())
                 .build();

--- a/src/main/java/com/beachape/auth/MyAuthMechanism.java
+++ b/src/main/java/com/beachape/auth/MyAuthMechanism.java
@@ -2,6 +2,8 @@ package com.beachape.auth;
 
 import org.jboss.logging.Logger;
 
+import static com.beachape.logging.MessageUtils.formatMessageWithThread;
+
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
@@ -19,7 +21,7 @@ public class MyAuthMechanism implements HttpAuthenticationMechanism {
 
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
-        LOGGER.info("Handling authentication in MyAuthMechanism");
+        LOGGER.info(formatMessageWithThread("Handling authentication in MyAuthMechanism"));
         String authorizationHeader = context.request().getHeader(HttpHeaders.AUTHORIZATION);
         if (authorizationHeader == null || !authorizationHeader.startsWith("Basic ")) {
             return Uni.createFrom().nullItem();

--- a/src/main/java/com/beachape/filters/ReqIdRequestFilter.java
+++ b/src/main/java/com/beachape/filters/ReqIdRequestFilter.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import org.jboss.logging.Logger;
 
+import static com.beachape.logging.MessageUtils.formatMessageWithThread;
+
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.ext.Provider;
@@ -17,7 +19,7 @@ public final class ReqIdRequestFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        LOGGER.info("Processing request in ReqIdRequestFilter");
+        LOGGER.info(formatMessageWithThread("Processing request in ReqIdRequestFilter"));
         var reqId = UUID.randomUUID().toString();
         requestContext.setProperty(PROPERTY_NAME, reqId);
     }

--- a/src/main/java/com/beachape/filters/ReqIdResponseFilter.java
+++ b/src/main/java/com/beachape/filters/ReqIdResponseFilter.java
@@ -2,6 +2,8 @@ package com.beachape.filters;
 
 import org.jboss.logging.Logger;
 
+import static com.beachape.logging.MessageUtils.formatMessageWithThread;
+
 import jakarta.ws.rs.ext.Provider;
 
 @Provider
@@ -14,13 +16,13 @@ public class ReqIdResponseFilter implements jakarta.ws.rs.container.ContainerRes
     @Override
     public void filter(jakarta.ws.rs.container.ContainerRequestContext requestContext,
             jakarta.ws.rs.container.ContainerResponseContext responseContext) {
-        LOGGER.info("Processing response in ReqIdResponseFilter");
+        LOGGER.info(formatMessageWithThread("Processing response in ReqIdResponseFilter"));
         var currentReqId = requestContext.getProperty(ReqIdRequestFilter.PROPERTY_NAME);
         if (currentReqId != null && currentReqId instanceof String) {
-            LOGGER.info("Using existing request ID: " + currentReqId);
+            LOGGER.info(formatMessageWithThread("Using existing request ID: " + currentReqId));
             responseContext.getHeaders().add(HEADER_NAME, currentReqId);
         } else {
-            LOGGER.info("No existing request ID found, generating a new one");
+            LOGGER.info(formatMessageWithThread("No existing request ID found, generating a new one"));
             String newReqId = java.util.UUID.randomUUID().toString();
             responseContext.getHeaders().add(HEADER_NAME, newReqId);
         }

--- a/src/main/java/com/beachape/logging/MessageUtils.java
+++ b/src/main/java/com/beachape/logging/MessageUtils.java
@@ -1,0 +1,14 @@
+package com.beachape.logging;
+
+public class MessageUtils {
+
+    /**
+     * Utility method to format a log message with the thread name.
+     *
+     * @param message the log message
+     * @return formatted log message with thread name
+     */
+    public static String formatMessageWithThread(String message) {
+        return String.format("[Thread:%s] %s", Thread.currentThread().getName(), message);
+    }
+}

--- a/src/main/java/com/beachape/routes/hello/GreetingResource.java
+++ b/src/main/java/com/beachape/routes/hello/GreetingResource.java
@@ -4,6 +4,8 @@ import java.security.Principal;
 
 import org.jboss.logging.Logger;
 
+import static com.beachape.logging.MessageUtils.formatMessageWithThread;
+
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -25,7 +27,7 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        LOGGER.info("Handling hello within GreetingResource");
+        LOGGER.info(formatMessageWithThread("Handling hello within GreetingResource"));
         return "Hello from Quarkus REST";
     }
 
@@ -34,13 +36,13 @@ public class GreetingResource {
     @Path("/say-my-name")
     @Produces(MediaType.TEXT_PLAIN)
     public String sayMyName(@Context SecurityIdentity securityIdentity) {
-        LOGGER.info("Handling say-my-name within GreetingResource");
+        LOGGER.info(formatMessageWithThread("Handling say-my-name within GreetingResource"));
         Principal principal = securityIdentity.getPrincipal();
         if (principal != null) {
-            LOGGER.info("Authenticated user: " + principal.getName());
+            LOGGER.info(formatMessageWithThread("Authenticated user: " + principal.getName()));
             return "Hello, " + principal.getName() + "!";
         } else {
-            LOGGER.warn("No authenticated user found in SecurityIdentity");
+            LOGGER.warn(formatMessageWithThread("No authenticated user found in SecurityIdentity"));
             return "Hello, anonymous user!";
         }
     }


### PR DESCRIPTION
This ensures we don't get caught out by any log handler behaviour: we get the actual name of the thread from inside the methods themselves, and then extract in tests.